### PR TITLE
add a DataImport class that will pick implementation based on source URL

### DIFF
--- a/README
+++ b/README
@@ -2,9 +2,10 @@ In order to use Yahoo Contacts
 
 1) Deploy this extension to /opt/zimbra/lib/ext/oauth2_datasources and restart mailboxd 
 2) set up the following localconfig keys:
- - yahoo_oauth2_client_secret (set to your OAuth2 client secret) 
- - yahoo_oauth2_client_id (set to your OAuth2 client ID)
- 
+ - zm_oauth_yahoo_client_secret (set to your OAuth2 client secret)
+ - zm_oauth_yahoo_client_id (set to your OAuth2 client ID)
+ - zm_oauth_yahoo_authenticate_uri (set to "https://api.login.yahoo.com/oauth2/get_token" unless Yahoo changes this URL)
+ - zm_oauth_yahoo_contacts_uri_template (set to "https://social.yahooapis.com/v1/user/%s/contacts?format=%s&count=%d" unless Yahoo changes the REST API for contacts)
  3) Create a datasource with type "oauth"
  e.g. via zmprov:
 
@@ -14,4 +15,9 @@ zmprov cds user1@zcs-dev.test oauth myadress@yahoo.com zimbraDataSourceEnabled T
  4) obtain an oauth2 refresh token from Yahoo API and assign it to the datasource:
 
 e.g. via zmprov:
-zmprov mds user1@zcs-dev.test myadress@yahoo.com zimbraDataSourceOAuthRefreshToken "AAwee1nfwk3VsVdNHR.l0_jzuXvPNiAt0DBOcRm9w9zq0dbA" 
+zmprov mds user1@zcs-dev.test myadress@yahoo.com zimbraDataSourceOAuthRefreshToken "AAwee1nfwk3VsVdNHR.l0_jzuXvPNiAt0DBOcRm9w9zq0dbA"
+
+Running SOAP tests
+SOAP tests included in this package require the following additional localconfig settings:
+ - zm_yahoo_test_account (to be set to yahoo ID, such as yourname@yahoo.com which has already authorized OAuth2 access to the application identified by zm_oauth_yahoo_client_secret) 
+ - zm_yahoo_test_refresh_token (OAuth2 refresh token obtained from Yahoo API)

--- a/src/java-test/com/synacor/zimbra/ys/contacts/YahooContactsUtilTest.java
+++ b/src/java-test/com/synacor/zimbra/ys/contacts/YahooContactsUtilTest.java
@@ -2,8 +2,40 @@
  * 
  */
 package com.synacor.zimbra.ys.contacts;
-import static com.zimbra.common.mailbox.ContactConstants.*;
-import static org.junit.Assert.*;
+import static com.zimbra.common.mailbox.ContactConstants.A_anniversary;
+import static com.zimbra.common.mailbox.ContactConstants.A_birthday;
+import static com.zimbra.common.mailbox.ContactConstants.A_company;
+import static com.zimbra.common.mailbox.ContactConstants.A_email;
+import static com.zimbra.common.mailbox.ContactConstants.A_email2;
+import static com.zimbra.common.mailbox.ContactConstants.A_firstName;
+import static com.zimbra.common.mailbox.ContactConstants.A_homeCity;
+import static com.zimbra.common.mailbox.ContactConstants.A_homeCountry;
+import static com.zimbra.common.mailbox.ContactConstants.A_homePhone;
+import static com.zimbra.common.mailbox.ContactConstants.A_homePhone2;
+import static com.zimbra.common.mailbox.ContactConstants.A_homePostalCode;
+import static com.zimbra.common.mailbox.ContactConstants.A_homeState;
+import static com.zimbra.common.mailbox.ContactConstants.A_homeStreet;
+import static com.zimbra.common.mailbox.ContactConstants.A_lastName;
+import static com.zimbra.common.mailbox.ContactConstants.A_middleName;
+import static com.zimbra.common.mailbox.ContactConstants.A_mobilePhone;
+import static com.zimbra.common.mailbox.ContactConstants.A_namePrefix;
+import static com.zimbra.common.mailbox.ContactConstants.A_nameSuffix;
+import static com.zimbra.common.mailbox.ContactConstants.A_otherCountry;
+import static com.zimbra.common.mailbox.ContactConstants.A_otherStreet;
+import static com.zimbra.common.mailbox.ContactConstants.A_workCity;
+import static com.zimbra.common.mailbox.ContactConstants.A_workCountry;
+import static com.zimbra.common.mailbox.ContactConstants.A_workEmail1;
+import static com.zimbra.common.mailbox.ContactConstants.A_workEmail2;
+import static com.zimbra.common.mailbox.ContactConstants.A_workPhone;
+import static com.zimbra.common.mailbox.ContactConstants.A_workPhone2;
+import static com.zimbra.common.mailbox.ContactConstants.A_workPostalCode;
+import static com.zimbra.common.mailbox.ContactConstants.A_workState;
+import static com.zimbra.common.mailbox.ContactConstants.A_workStreet;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 import java.util.HashMap;
 import java.util.Locale;
@@ -11,11 +43,9 @@ import java.util.Map;
 
 import org.junit.Test;
 
-import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import com.zimbra.common.service.ServiceException;
-import com.zimbra.cs.account.Provisioning;
 import com.zimbra.cs.mime.ParsedContact;
 
 /**

--- a/src/java/com/synacor/zimbra/OAuth2DataSourcesExtension.java
+++ b/src/java/com/synacor/zimbra/OAuth2DataSourcesExtension.java
@@ -6,7 +6,10 @@ import com.zimbra.cs.extension.ExtensionException;
 import com.zimbra.cs.extension.ZimbraExtension;
 import com.zimbra.qa.unittest.TestYahooContactsImport;
 import com.zimbra.qa.unittest.ZimbraSuite;
-
+/**
+ * @author Greg Solovyev
+ *
+ */
 public class OAuth2DataSourcesExtension implements ZimbraExtension {
 
     @Override

--- a/src/java/com/synacor/zimbra/OAuthDataImport.java
+++ b/src/java/com/synacor/zimbra/OAuthDataImport.java
@@ -4,7 +4,9 @@ import com.zimbra.cs.account.DataSource;
 
 import java.util.List;
 
+import com.zimbra.client.ZDataSource;
 import com.zimbra.common.service.ServiceException;
+import com.zimbra.common.util.ZimbraLog;
 import com.zimbra.cs.account.DataSource.DataImport;
 /**
  * @author Greg Solovyev
@@ -13,23 +15,32 @@ import com.zimbra.cs.account.DataSource.DataImport;
  */
 public class OAuthDataImport implements DataImport {
     private DataImport implementation;
+    private String source = null;
     public OAuthDataImport(DataSource ds) {
-        String sourceURL = ds.getOauthRefreshTokenUrl();
-        if(sourceURL.indexOf("api.login.yahoo.com/oauth2/get_token") > -1) {
+        source = ds.getHost();
+        if(source.equalsIgnoreCase(ZDataSource.SOURCE_HOST_YAHOO)) {
             implementation = new YahooContactsImport(ds);
         } else {
-            throw new UnsupportedOperationException(String.format("No known DataImport implementation for oauth URL %", sourceURL));
+            ZimbraLog.extensions.error(new UnsupportedOperationException(String.format("No known DataImport implementation for %s", source)));
         }
     }
 
     @Override
     public void test() throws ServiceException {
-        implementation.test();
+        if(implementation == null) {
+            throw new UnsupportedOperationException(String.format("No known DataImport implementation for %s", source));
+        } else {
+            implementation.test();
+        }
 
     }
 
     @Override
     public void importData(List<Integer> folderIds, boolean fullSync) throws ServiceException {
-        implementation.importData(folderIds, fullSync);
+        if(implementation == null) {
+            throw new UnsupportedOperationException(String.format("No known DataImport implementation for %s", source));
+        } else {
+            implementation.importData(folderIds, fullSync);
+        }
     }
 }

--- a/src/java/com/synacor/zimbra/OAuthDataImport.java
+++ b/src/java/com/synacor/zimbra/OAuthDataImport.java
@@ -1,0 +1,35 @@
+package com.synacor.zimbra;
+import com.synacor.zimbra.ys.contacts.YahooContactsImport;
+import com.zimbra.cs.account.DataSource;
+
+import java.util.List;
+
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.cs.account.DataSource.DataImport;
+/**
+ * @author Greg Solovyev
+ * DataImport class that picks source-specific implementation based on oauth2 URL. 
+ * This class will only be aware of implementations packaged together with this class.
+ */
+public class OAuthDataImport implements DataImport {
+    private DataImport implementation;
+    public OAuthDataImport(DataSource ds) {
+        String sourceURL = ds.getOauthRefreshTokenUrl();
+        if(sourceURL.indexOf("api.login.yahoo.com/oauth2/get_token") > -1) {
+            implementation = new YahooContactsImport(ds);
+        } else {
+            throw new UnsupportedOperationException(String.format("No known DataImport implementation for oauth URL %", sourceURL));
+        }
+    }
+
+    @Override
+    public void test() throws ServiceException {
+        implementation.test();
+
+    }
+
+    @Override
+    public void importData(List<Integer> folderIds, boolean fullSync) throws ServiceException {
+        implementation.importData(folderIds, fullSync);
+    }
+}

--- a/src/java/com/synacor/zimbra/ys/contacts/YahooContactsImport.java
+++ b/src/java/com/synacor/zimbra/ys/contacts/YahooContactsImport.java
@@ -32,6 +32,10 @@ import com.zimbra.cs.account.DataSource;
 import com.zimbra.cs.account.DataSource.DataImport;
 import com.zimbra.cs.account.Provisioning;
 import com.zimbra.cs.mime.ParsedContact;
+/**
+ * @author Greg Solovyev
+ *
+ */
 public class YahooContactsImport implements DataImport {
     private static String DEFAULT_CONTACTS_URL = "https://social.yahooapis.com/v1/user/%s/contacts?format=%s&count=%d";
 

--- a/src/java/com/synacor/zimbra/ys/contacts/YahooContactsImport.java
+++ b/src/java/com/synacor/zimbra/ys/contacts/YahooContactsImport.java
@@ -38,6 +38,7 @@ import com.zimbra.cs.mime.ParsedContact;
  */
 public class YahooContactsImport implements DataImport {
     private static String DEFAULT_CONTACTS_URL = "https://social.yahooapis.com/v1/user/%s/contacts?format=%s&count=%d";
+    private static String DEFAULT_TOKEN_URL = "https://api.login.yahoo.com/oauth2/get_token";
 
     private DataSource mDataSource;
     public YahooContactsImport(DataSource ds) {
@@ -46,7 +47,7 @@ public class YahooContactsImport implements DataImport {
 
     @Override
     public void test() throws ServiceException {
-        String YSocialURLPattern = LC.get("yahoo_social_contacts_url_pattern");
+        String YSocialURLPattern = LC.get("zm_oauth_yahoo_contacts_uri_template");
         if(YSocialURLPattern == null || YSocialURLPattern.isEmpty()) {
             YSocialURLPattern = DEFAULT_CONTACTS_URL;
         }
@@ -101,13 +102,17 @@ public class YahooContactsImport implements DataImport {
     }
 
     private Pair<String, String> getAccessTokenAndGuid() throws ServiceException {
-        String clientId = LC.get("yahoo_oauth2_client_id");
+        String clientId = LC.get("zm_oauth_yahoo_client_id");
         if(clientId == null || clientId.isEmpty()) {
             throw ServiceException.FAILURE("yahoo_oauth2_client_id is not set in local config. Cannot access Yahoo API without a valid yahoo_oauth2_client_id.", null);
         }
-        String clientSecret = LC.get("yahoo_oauth2_client_secret");
+        String clientSecret = LC.get("zm_oauth_yahoo_client_secret");
         if(clientSecret == null || clientSecret.isEmpty()) {
             throw ServiceException.FAILURE("yahoo_oauth2_client_secret is not set in local config. Cannot access Yahoo API without a valid yahoo_oauth2_client_secret.", null);
+        }
+        String tokenUrl = LC.get("zm_oauth_yahoo_authenticate_uri");
+        if(tokenUrl == null || tokenUrl.isEmpty()) {
+            tokenUrl = DEFAULT_TOKEN_URL;
         }
         if(mDataSource == null) {
             throw ServiceException.FAILURE("DataSource object is NULL", null);
@@ -116,13 +121,9 @@ public class YahooContactsImport implements DataImport {
         if(refreshToken == null || refreshToken.isEmpty()) {
             throw ServiceException.FAILURE(String.format("Refresh token is not set for DataSource %s of Account %s. Cannot access Yahoo API without a valid refresh token.", mDataSource.getName(), mDataSource.getAccountId()), null);
         }
-        String tokenUrl = mDataSource.getOauthRefreshTokenUrl();
-        if(tokenUrl == null || tokenUrl.isEmpty()) {
-            throw ServiceException.FAILURE(String.format("Refresh token URL is not set for DataSource %s of Account %s. Cannot access Yahoo API without a valid refresh token URL.", mDataSource.getName(), mDataSource.getAccountId()), null);
-        }
         String accessToken = null;
         String YGuid = null;
-        HttpPost post = new HttpPost(mDataSource.getOauthRefreshTokenUrl());
+        HttpPost post = new HttpPost(tokenUrl);
         List<NameValuePair> params = new ArrayList<NameValuePair>();
         params.add(new BasicNameValuePair("refresh_token", refreshToken));
         params.add(new BasicNameValuePair("grant_type", "refresh_token"));

--- a/src/java/com/synacor/zimbra/ys/contacts/YahooContactsUtil.java
+++ b/src/java/com/synacor/zimbra/ys/contacts/YahooContactsUtil.java
@@ -59,7 +59,10 @@ import com.zimbra.common.util.ZimbraLog;
 import com.zimbra.cs.account.DataSource;
 import com.zimbra.cs.account.Provisioning;
 import com.zimbra.cs.mime.ParsedContact;
-
+/**
+ * @author Greg Solovyev
+ *
+ */
 @SuppressWarnings("serial")
 public class YahooContactsUtil {
     static enum YContactFieldType {

--- a/src/java/com/zimbra/qa/unittest/TestYahooContactsImport.java
+++ b/src/java/com/zimbra/qa/unittest/TestYahooContactsImport.java
@@ -58,7 +58,7 @@ public class TestYahooContactsImport {
     public void test() throws ServiceException {
         ZMailbox zmbox = TestUtil.getZMailbox(USER_NAME);
         ZFolder folder = TestUtil.createFolder(zmbox, "/testCustomDS");
-        ZOAuthDataSource zds = new ZOAuthDataSource(yahooTestAccount, true, testToken, "https://api.login.yahoo.com/oauth2/get_token", folder.getId(), "com.synacor.zimbra.ys.contacts.YahooContactsImport", true);
+        ZOAuthDataSource zds = new ZOAuthDataSource(yahooTestAccount, true, testToken, "https://api.login.yahoo.com/oauth2/get_token", folder.getId(), "com.synacor.zimbra.OAuthDataImport", true);
         String dsId = zmbox.createDataSource(zds);
         zds.setId(dsId);
         String result = zmbox.testDataSource(zds);

--- a/src/java/com/zimbra/qa/unittest/TestYahooContactsImport.java
+++ b/src/java/com/zimbra/qa/unittest/TestYahooContactsImport.java
@@ -1,6 +1,8 @@
 package com.zimbra.qa.unittest;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 import org.junit.After;
 import org.junit.Before;
@@ -8,11 +10,10 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
 
+import com.zimbra.client.ZDataSource;
 import com.zimbra.client.ZFolder;
 import com.zimbra.client.ZMailbox;
-import com.zimbra.client.ZOAuthDataSource;
 import com.zimbra.common.localconfig.LC;
-import com.zimbra.common.service.ServiceException;
 /**
  * @author Greg Solovyev
  *
@@ -29,14 +30,14 @@ public class TestYahooContactsImport {
 
     @Before
     public void setUp() throws Exception {
-        clientId = LC.get("yahoo_oauth2_client_id");
-        TestUtil.assumeTrue("yahoo_oauth2_client_id is not set. This LC setting is required to use YahooContactsImport.", clientId != null && !clientId.isEmpty());
-        clientSecret = LC.get("yahoo_oauth2_client_secret");
-        TestUtil.assumeTrue("yahoo_oauth2_client_secret is not set. This LC setting is required to use YahooContactsImport.", clientSecret != null && !clientSecret.isEmpty());
-        yahooTestAccount = LC.get("yahoo_test_account");
-        TestUtil.assumeTrue("yahoo_test_account is not set. This LC setting is required to run the SOAP tests for YahooContactsImport.", yahooTestAccount != null && !yahooTestAccount.isEmpty());
-        testToken = LC.get("yahoo_test_refresh_token");
-        TestUtil.assumeTrue("yahoo_test_refresh_token is not set. This LC setting is required to run the SOAP tests for YahooContactsImport.", testToken != null && !testToken.isEmpty());
+        clientId = LC.get("zm_oauth_yahoo_client_id");
+        TestUtil.assumeTrue("zm_oauth_yahoo_client_id is not set. This LC setting is required to use YahooContactsImport.", clientId != null && !clientId.isEmpty());
+        clientSecret = LC.get("zm_oauth_yahoo_client_secret");
+        TestUtil.assumeTrue("zm_oauth_yahoo_client_secret is not set. This LC setting is required to use YahooContactsImport.", clientSecret != null && !clientSecret.isEmpty());
+        yahooTestAccount = LC.get("zm_yahoo_test_account");
+        TestUtil.assumeTrue("zm_yahoo_test_account is not set. This LC setting is required to run the SOAP tests for YahooContactsImport.", yahooTestAccount != null && !yahooTestAccount.isEmpty());
+        testToken = LC.get("zm_yahoo_test_refresh_token");
+        TestUtil.assumeTrue("zm_yahoo_test_refresh_token is not set. This LC setting is required to run the SOAP tests for YahooContactsImport.", testToken != null && !testToken.isEmpty());
         testId = String.format("%s-%s-%d", this.getClass().getSimpleName(), testInfo.getMethodName(), (int)Math.abs(Math.random()*100));
         USER_NAME = String.format("%s-user", testId).toLowerCase();
         cleanUp();
@@ -55,14 +56,33 @@ public class TestYahooContactsImport {
     }
 
     @Test
-    public void test() throws ServiceException {
+    public void test() throws Exception {
         ZMailbox zmbox = TestUtil.getZMailbox(USER_NAME);
         ZFolder folder = TestUtil.createFolder(zmbox, "/testCustomDS");
-        ZOAuthDataSource zds = new ZOAuthDataSource(yahooTestAccount, true, testToken, "https://api.login.yahoo.com/oauth2/get_token", folder.getId(), "com.synacor.zimbra.OAuthDataImport", true);
+        ZDataSource zds = new ZDataSource(yahooTestAccount, true);
+        zds.setImportClass("com.synacor.zimbra.OAuthDataImport");
+        zds.setRefreshToken(testToken);
+        zds.setHost(ZDataSource.SOURCE_HOST_YAHOO);
+        zds.setFolderId(folder.getId());
         String dsId = zmbox.createDataSource(zds);
         zds.setId(dsId);
         String result = zmbox.testDataSource(zds);
         assertNull("test should return null on success. Returned: " + result, result);
     }
 
+    @Test
+    public void testInvalidSource() throws Exception {
+        ZMailbox zmbox = TestUtil.getZMailbox(USER_NAME);
+        ZFolder folder = TestUtil.createFolder(zmbox, "/testCustomDS");
+        ZDataSource zds = new ZDataSource(yahooTestAccount, true);
+        zds.setImportClass("com.synacor.zimbra.OAuthDataImport");
+        zds.setRefreshToken(testToken);
+        zds.setHost("unknown.host");
+        zds.setFolderId(folder.getId());
+        String dsId = zmbox.createDataSource(zds);
+        zds.setId(dsId);
+        String result = zmbox.testDataSource(zds);
+        assertNotNull("DataImport::test should return non-null on error.", result);
+        assertTrue("Expecting No known DataImport implementation for unknown.host in the error message", result.indexOf("No known DataImport implementation for unknown.host") >-1);
+    }
 }


### PR DESCRIPTION
@desouzas pointed out that passing different DataImport implementation classname to ZMailbox::createDataSource based on the source is unnecessary. Each contacts API is unique and therefore the mapping cannot change without changing the code, so we may as well store the mapping inside the code.
With this change the oauth2 service will always call ZMailbox::createDataSource will "com.synacor.zimbra.OAuthDataImport" as the value for "importClass" - as in the SOAP test in this extension.