### PR TITLE
ZCS-8017: updating guava version to 28.1-jre from 23.0 and centrally

### DIFF
--- a/ivy.xml
+++ b/ivy.xml
@@ -22,7 +22,7 @@
   <dependency org="com.google.code.gson" name="gson" rev="2.8.1"/>
   <dependency org="javax.mail" name="mail" rev="1.4.5" />
   <dependency org="org.json" name="json" rev="20090211" />
-  <dependency org="com.google.guava" name="guava" rev="13.0.1" />  
+  <dependency org="com.google.guava" name="guava" rev="${com.google.guava.version}" />
   <dependency org="com.unboundid" name="unboundid-ldapsdk" rev="2.3.5" />
  </dependencies>
 </ivy-module>


### PR DESCRIPTION
Issue:
Vulnerabilities in older version 23.0 of Guava.

Fix:
Update version to 28.1-jre and make it available centrally